### PR TITLE
adding "overlap" as commandline command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,19 @@ $ nosetests
 ```
 
 The output will tell you whether your mapping has succeded. If you run into problems, just let us know, and we try to help as best as we can.
+
+## Conventions
+
+We have certain conventions on how to deal with problems when linking concepts to the Concepticon. Here, we currently list them without specific order of preference.
+
+### Missing translations
+
+Missing translations are indicated as NAN, as an example see the list by `Pallas-1786-441`.
+
+### Missing Concept Sets
+
+If we don't find a concept set for a concept and deem the concept to be to specific to be further mapped, we leave the field empty. All these concept sets are later assigned to a class of concept sets called "NAN".
+
+### N-N Mappings
+
+We do NOT allow to carry out N-N mappings between concepts in a concept lists and concept sets in the Concepticon. As a work-around, however, we allow to multiple a respective concept in a given source and assign it to two different concept sets. This has been done, for example, in the list [Matisoff-1978-200](https://github.com/clld/concepticon-data/blob/master/concepticondata/conceptlists/Matisoff-1978-200.tsv#L31), where the concept "vagina or breast/milk" clearly indicates that the author means two distinct entries, but lists them in the same line of the list. Similarly, one may encounter that people make a further distinction within a wordlist, by adding in brackets that, for example, there are actually two words for "frog" in some varieties, a "big frog" and a "small frog". In these cases it is also important to split the respective entry, as it has been done in the list by [List-2016-180](https://github.com/clld/concepticon-data/blob/master/concepticondata/conceptlists/List-2016-180.tsv#L8), although, admittedly, the actual decision was already done in the compilation of the concept list. 

--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ Concept(id=u'Mennecier-2016-183-1', number=u'1', concepticon_id=u'619', concepti
 >>> api.bibliography.values()[0]
 Reference(id=u'Mennecier2016', type=u'article', record={u'doi': u'10.1163/22105832-00601015', u'author': u'Phillipe Mennecier and John Nerbonne and Evelyne Heyer and Franz Manni', u'journal': u'Language Dynamics and Change', u'title': u'A Central Asian language survey', u'number': u'1', u'volume': u'6', u'year': u'2016', u'pages': u'57\u201398'})
 ```
+
+Having installed pyconcepticon, you can also directly query concept lists via the terminal command `concepticon`. For example, to lear about the overlap between two or more lists, you can type:
+
+```shell
+$ concepticon overlap Swadesh-1955-100 Swadesh-1952-200 Swadesh-1950-215
+85
+```
+So the overlap between the three lists by Swadesh are 85 concepts.

--- a/concepticondata/conceptlists/List-2016-180.tsv
+++ b/concepticondata/conceptlists/List-2016-180.tsv
@@ -14,7 +14,7 @@ List-2016-180-12	12	the hail	冰雹	11	6	609	HAIL
 List-2016-180-13	13	the ant	螞蟻	117	59	587	ANT
 List-2016-180-14	14	the mosquito	蚊子	119	60	1509	MOSQUITO
 List-2016-180-15	15	the spider	蜘蛛	121	61	843	SPIDER
-List-2016-180-16	16	to make a journey	趟(走一趟）	866	433	
+List-2016-180-16	16	to make a journey	趟(走一趟）	866	433		
 List-2016-180-17	17	the snake	蛇	123	62	730	SNAKE
 List-2016-180-18	18	the wing	翅膀	125	63	1257	WING
 List-2016-180-19	19	the hoof	蹄子	126	63	152	HOOF

--- a/concepticondata/conceptlists/Pallas-1786-441.tsv
+++ b/concepticondata/conceptlists/Pallas-1786-441.tsv
@@ -12,7 +12,7 @@ Pallas-1786-441-11	10	Дѣва	girl (noun)	Maedchen	Puella	Fille	1646	GIRL
 Pallas-1786-441-12	11	Мальчикъ	boy (noun)	Knabe	Puer	Garҫon	1366	BOY
 Pallas-1786-441-13	12	Дитя	child (descendant, noun)	Kind	Infans	Enfant	2099	CHILD
 Pallas-1786-441-14	13	Человѣкъ	person (noun)	Menßch	Homo	Homme	683	PERSON
-Pallas-1786-441-15	14	Люди	people (noun)	Leute	?	Gens	789	PEOPLE
+Pallas-1786-441-15	14	Люди	people (noun)	Leute	NAN	Gens	789	PEOPLE
 Pallas-1786-441-16	15	Глава	head (noun)	Kopf	Caput	Tête	1256	HEAD
 Pallas-1786-441-17	16	Лицо	face (noun)	Antlitz	Facies	Vißage (Face)	1560	FACE
 Pallas-1786-441-18	17	Носъ	nose (noun)	Naße	Naßus	Nez	1221	NOSE
@@ -149,7 +149,7 @@ Pallas-1786-441-148	147	Тепло	warm (adjective)	Warm	Calidus	Chaud	1232	WARM
 Pallas-1786-441-149	148	Жарко	hot (adjective)	Heißs	Fervidus	Ardent	1286	HOT
 Pallas-1786-441-150	149	Зсравъ	healthy (adjective)	Geßund	Sanus	Sain	1364	HEALTHY
 Pallas-1786-441-151	150	Хорошо	good (adjective)	Gut	Bene, Bonus	Bien, Bon	1035	GOOD
-Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig	?	Biènheureu	2529	BLESSED
+Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig	NAN	Biènheureu	2529	BLESSED
 Pallas-1786-441-153	152	Зло	evil (adjective)	Böße	Sceleratus	Méchant	45	EVIL
 Pallas-1786-441-154	153	Дурно	bad (adjective)	Schlecht	Male	Mal	1292	BAD
 Pallas-1786-441-155	154	Глупо	stupid (adjective)	Dumm	Stultus	Sot	1518	STUPID
@@ -330,7 +330,7 @@ Pallas-1786-441-329	328	Яицо	egg (noun)	Ey	Ovum	Oeuf	744	EGG
 Pallas-1786-441-330	329	Гнѣздо	nest (noun)	Neßt	Nidus	Nid	539	NEST
 Pallas-1786-441-331	330	Пастухъ	shepherd (noun)	Hirte	Paßtor	Berger	2544	SHEPHERD
 Pallas-1786-441-332	331	Пахать	to plow, plough (verb)	Pflügen	Arare	Labourer	1921	PLOUGH
-Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum	?	2154	PLOUGH (INSTRUMENT)
+Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum	NAN	2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-334	333	Плугъ	plough (noun)	Pflug	Aratum	Charue	2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-335	334	Борона	harrow (noun)	Egge	Occa	Herße	2545	HARROW (TOOL)
 Pallas-1786-441-336	335	Жатва	harvest (noun)	Erndte	Meßßis	Recolte	611	HARVEST
@@ -354,11 +354,11 @@ Pallas-1786-441-353	352	Судно	ship (noun)	Küße, Schif	Navis	Vaißßeau	74
 Pallas-1786-441-354	353	Лодья	boat (noun)	Kahn	Scapha	Eßquif	1844	BOAT
 Pallas-1786-441-355	354	Возъ	vehicle (noun)	Fuhre	Vectura	Voiture	2549	VEHICLE
 Pallas-1786-441-356	355	Возить	to drive (a vehicle, verb)	Führen	Veture	Voiturer	741	DRIVE
-Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi	?	741	DRIVE
+Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi	NAN	741	DRIVE
 Pallas-1786-441-358	357	Строить	to build (verb)	Bauen	Struere	Batir	1840	BUILD
 Pallas-1786-441-359	358	Платье	clothing (noun)	Kleidung	Veßtis	Vetement	1895	CLOTHES
 Pallas-1786-441-360	359	Шуба	fur, pelt (noun)	Peltz	Pelliceamentum	Pelißße	580	FUR
-Pallas-1786-441-361	360	Обувь	shoe (noun)	?	?	Chaußßure	1381	SHOE
+Pallas-1786-441-361	360	Обувь	shoe (noun)	NAN	NAN	Chaußßure	1381	SHOE
 Pallas-1786-441-362	361	Чулокъ	sock (noun)	Strumpf	Tibiale	Bas	1522	SOCK
 Pallas-1786-441-363	362	Башмакъ	shoe, boot (noun)	Schu	Calceus	Souiller	1381	SHOE
 Pallas-1786-441-364	363	Шапка	cap, hat (noun)	Mütze	Mitra	Bonnet	771	HAT
@@ -367,7 +367,7 @@ Pallas-1786-441-366	365	Шелкъ	silk (noun)	Seyde	Seridum	Soye	1641	SILK
 Pallas-1786-441-367	366	Шерсть	wool (noun)	Wolle	Lana	Laine	964	WOOL
 Pallas-1786-441-368	367	Бумага	cotton (noun)	Baumwolle	Goßßypium	Coton	1850	COTTON
 Pallas-1786-441-369	368	Ленъ	linen (noun)	Flachs, Lein	Linum	Lin	916	LINEN
-Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca	?	2550	VIANDS (PROVISIONS)
+Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca	NAN	2550	VIANDS (PROVISIONS)
 Pallas-1786-441-371	370	Сыро	raw (noun)	Roh	Crudus	Crû	1959	RAW
 Pallas-1786-441-372	371	Варить	to boil (verb)	Kochen	Coquere	Cuire	1100	COOK (SOMETHING)
 Pallas-1786-441-373	372	Пиво	beer (noun)	Bier	Cervißia	Bière	1639	BEER

--- a/concepticondata/conceptlists/Pallas-1786-441.tsv
+++ b/concepticondata/conceptlists/Pallas-1786-441.tsv
@@ -12,7 +12,7 @@ Pallas-1786-441-11	10	Дѣва	girl (noun)	Maedchen	Puella	Fille	1646	GIRL
 Pallas-1786-441-12	11	Мальчикъ	boy (noun)	Knabe	Puer	Garҫon	1366	BOY
 Pallas-1786-441-13	12	Дитя	child (descendant, noun)	Kind	Infans	Enfant	2099	CHILD
 Pallas-1786-441-14	13	Человѣкъ	person (noun)	Menßch	Homo	Homme	683	PERSON
-Pallas-1786-441-15	14	Люди	people (noun)	Leute		Gens	789	PEOPLE
+Pallas-1786-441-15	14	Люди	people (noun)	Leute	?	Gens	789	PEOPLE
 Pallas-1786-441-16	15	Глава	head (noun)	Kopf	Caput	Tête	1256	HEAD
 Pallas-1786-441-17	16	Лицо	face (noun)	Antlitz	Facies	Vißage (Face)	1560	FACE
 Pallas-1786-441-18	17	Носъ	nose (noun)	Naße	Naßus	Nez	1221	NOSE
@@ -149,7 +149,7 @@ Pallas-1786-441-148	147	Тепло	warm (adjective)	Warm	Calidus	Chaud	1232	WARM
 Pallas-1786-441-149	148	Жарко	hot (adjective)	Heißs	Fervidus	Ardent	1286	HOT
 Pallas-1786-441-150	149	Зсравъ	healthy (adjective)	Geßund	Sanus	Sain	1364	HEALTHY
 Pallas-1786-441-151	150	Хорошо	good (adjective)	Gut	Bene, Bonus	Bien, Bon	1035	GOOD
-Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig		Biènheureu	2529	BLESSED
+Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig	?	Biènheureu	2529	BLESSED
 Pallas-1786-441-153	152	Зло	evil (adjective)	Böße	Sceleratus	Méchant	45	EVIL
 Pallas-1786-441-154	153	Дурно	bad (adjective)	Schlecht	Male	Mal	1292	BAD
 Pallas-1786-441-155	154	Глупо	stupid (adjective)	Dumm	Stultus	Sot	1518	STUPID
@@ -330,7 +330,7 @@ Pallas-1786-441-329	328	Яицо	egg (noun)	Ey	Ovum	Oeuf	744	EGG
 Pallas-1786-441-330	329	Гнѣздо	nest (noun)	Neßt	Nidus	Nid	539	NEST
 Pallas-1786-441-331	330	Пастухъ	shepherd (noun)	Hirte	Paßtor	Berger	2544	SHEPHERD
 Pallas-1786-441-332	331	Пахать	to plow, plough (verb)	Pflügen	Arare	Labourer	1921	PLOUGH
-Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum		2154	PLOUGH (INSTRUMENT)
+Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum	?	2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-334	333	Плугъ	plough (noun)	Pflug	Aratum	Charue	2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-335	334	Борона	harrow (noun)	Egge	Occa	Herße	2545	HARROW (TOOL)
 Pallas-1786-441-336	335	Жатва	harvest (noun)	Erndte	Meßßis	Recolte	611	HARVEST
@@ -354,11 +354,11 @@ Pallas-1786-441-353	352	Судно	ship (noun)	Küße, Schif	Navis	Vaißßeau	74
 Pallas-1786-441-354	353	Лодья	boat (noun)	Kahn	Scapha	Eßquif	1844	BOAT
 Pallas-1786-441-355	354	Возъ	vehicle (noun)	Fuhre	Vectura	Voiture	2549	VEHICLE
 Pallas-1786-441-356	355	Возить	to drive (a vehicle, verb)	Führen	Veture	Voiturer	741	DRIVE
-Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi		741	DRIVE
+Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi	?	741	DRIVE
 Pallas-1786-441-358	357	Строить	to build (verb)	Bauen	Struere	Batir	1840	BUILD
 Pallas-1786-441-359	358	Платье	clothing (noun)	Kleidung	Veßtis	Vetement	1895	CLOTHES
 Pallas-1786-441-360	359	Шуба	fur, pelt (noun)	Peltz	Pelliceamentum	Pelißße	580	FUR
-Pallas-1786-441-361	360	Обувь	shoe (noun)		-	Chaußßure	1381	SHOE
+Pallas-1786-441-361	360	Обувь	shoe (noun)	?	?	Chaußßure	1381	SHOE
 Pallas-1786-441-362	361	Чулокъ	sock (noun)	Strumpf	Tibiale	Bas	1522	SOCK
 Pallas-1786-441-363	362	Башмакъ	shoe, boot (noun)	Schu	Calceus	Souiller	1381	SHOE
 Pallas-1786-441-364	363	Шапка	cap, hat (noun)	Mütze	Mitra	Bonnet	771	HAT
@@ -367,7 +367,7 @@ Pallas-1786-441-366	365	Шелкъ	silk (noun)	Seyde	Seridum	Soye	1641	SILK
 Pallas-1786-441-367	366	Шерсть	wool (noun)	Wolle	Lana	Laine	964	WOOL
 Pallas-1786-441-368	367	Бумага	cotton (noun)	Baumwolle	Goßßypium	Coton	1850	COTTON
 Pallas-1786-441-369	368	Ленъ	linen (noun)	Flachs, Lein	Linum	Lin	916	LINEN
-Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca		2550	VIANDS (PROVISIONS)
+Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca	?	2550	VIANDS (PROVISIONS)
 Pallas-1786-441-371	370	Сыро	raw (noun)	Roh	Crudus	Crû	1959	RAW
 Pallas-1786-441-372	371	Варить	to boil (verb)	Kochen	Coquere	Cuire	1100	COOK (SOMETHING)
 Pallas-1786-441-373	372	Пиво	beer (noun)	Bier	Cervißia	Bière	1639	BEER

--- a/concepticondata/conceptlists/Pallas-1786-441.tsv
+++ b/concepticondata/conceptlists/Pallas-1786-441.tsv
@@ -12,7 +12,7 @@ Pallas-1786-441-11	10	Дѣва	girl (noun)	Maedchen	Puella	Fille	1646	GIRL
 Pallas-1786-441-12	11	Мальчикъ	boy (noun)	Knabe	Puer	Garҫon	1366	BOY
 Pallas-1786-441-13	12	Дитя	child (descendant, noun)	Kind	Infans	Enfant	2099	CHILD
 Pallas-1786-441-14	13	Человѣкъ	person (noun)	Menßch	Homo	Homme	683	PERSON
-Pallas-1786-441-15	14	Люди	people (noun)	Leute	?	Gens	789	PEOPLE
+Pallas-1786-441-15	14	Люди	people (noun)	Leute		Gens	789	PEOPLE
 Pallas-1786-441-16	15	Глава	head (noun)	Kopf	Caput	Tête	1256	HEAD
 Pallas-1786-441-17	16	Лицо	face (noun)	Antlitz	Facies	Vißage (Face)	1560	FACE
 Pallas-1786-441-18	17	Носъ	nose (noun)	Naße	Naßus	Nez	1221	NOSE
@@ -149,7 +149,7 @@ Pallas-1786-441-148	147	Тепло	warm (adjective)	Warm	Calidus	Chaud	1232	WARM
 Pallas-1786-441-149	148	Жарко	hot (adjective)	Heißs	Fervidus	Ardent	1286	HOT
 Pallas-1786-441-150	149	Зсравъ	healthy (adjective)	Geßund	Sanus	Sain	1364	HEALTHY
 Pallas-1786-441-151	150	Хорошо	good (adjective)	Gut	Bene, Bonus	Bien, Bon	1035	GOOD
-Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig	?	Biènheureu	2529	BLESSED
+Pallas-1786-441-152	151	Благъ	blessed (adjective)	Wohl, Seelig		Biènheureu	2529	BLESSED
 Pallas-1786-441-153	152	Зло	evil (adjective)	Böße	Sceleratus	Méchant	45	EVIL
 Pallas-1786-441-154	153	Дурно	bad (adjective)	Schlecht	Male	Mal	1292	BAD
 Pallas-1786-441-155	154	Глупо	stupid (adjective)	Dumm	Stultus	Sot	1518	STUPID
@@ -330,7 +330,7 @@ Pallas-1786-441-329	328	Яицо	egg (noun)	Ey	Ovum	Oeuf	744	EGG
 Pallas-1786-441-330	329	Гнѣздо	nest (noun)	Neßt	Nidus	Nid	539	NEST
 Pallas-1786-441-331	330	Пастухъ	shepherd (noun)	Hirte	Paßtor	Berger	2544	SHEPHERD
 Pallas-1786-441-332	331	Пахать	to plow, plough (verb)	Pflügen	Arare	Labourer	1921	PLOUGH
-Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum	-	2154	PLOUGH (INSTRUMENT)
+Pallas-1786-441-333	332	Соха	plough (noun)	Pflughaken	Aratum		2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-334	333	Плугъ	plough (noun)	Pflug	Aratum	Charue	2154	PLOUGH (INSTRUMENT)
 Pallas-1786-441-335	334	Борона	harrow (noun)	Egge	Occa	Herße	2545	HARROW (TOOL)
 Pallas-1786-441-336	335	Жатва	harvest (noun)	Erndte	Meßßis	Recolte	611	HARVEST
@@ -354,11 +354,11 @@ Pallas-1786-441-353	352	Судно	ship (noun)	Küße, Schif	Navis	Vaißßeau	74
 Pallas-1786-441-354	353	Лодья	boat (noun)	Kahn	Scapha	Eßquif	1844	BOAT
 Pallas-1786-441-355	354	Возъ	vehicle (noun)	Fuhre	Vectura	Voiture	2549	VEHICLE
 Pallas-1786-441-356	355	Возить	to drive (a vehicle, verb)	Führen	Veture	Voiturer	741	DRIVE
-Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi	-	741	DRIVE
+Pallas-1786-441-357	356	ѣхать	to drive (in a vehicle, verb)	Fahren	vehi		741	DRIVE
 Pallas-1786-441-358	357	Строить	to build (verb)	Bauen	Struere	Batir	1840	BUILD
 Pallas-1786-441-359	358	Платье	clothing (noun)	Kleidung	Veßtis	Vetement	1895	CLOTHES
 Pallas-1786-441-360	359	Шуба	fur, pelt (noun)	Peltz	Pelliceamentum	Pelißße	580	FUR
-Pallas-1786-441-361	360	Обувь	shoe (noun)	-	-	Chaußßure	1381	SHOE
+Pallas-1786-441-361	360	Обувь	shoe (noun)		-	Chaußßure	1381	SHOE
 Pallas-1786-441-362	361	Чулокъ	sock (noun)	Strumpf	Tibiale	Bas	1522	SOCK
 Pallas-1786-441-363	362	Башмакъ	shoe, boot (noun)	Schu	Calceus	Souiller	1381	SHOE
 Pallas-1786-441-364	363	Шапка	cap, hat (noun)	Mütze	Mitra	Bonnet	771	HAT
@@ -367,7 +367,7 @@ Pallas-1786-441-366	365	Шелкъ	silk (noun)	Seyde	Seridum	Soye	1641	SILK
 Pallas-1786-441-367	366	Шерсть	wool (noun)	Wolle	Lana	Laine	964	WOOL
 Pallas-1786-441-368	367	Бумага	cotton (noun)	Baumwolle	Goßßypium	Coton	1850	COTTON
 Pallas-1786-441-369	368	Ленъ	linen (noun)	Flachs, Lein	Linum	Lin	916	LINEN
-Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca	-	2550	VIANDS (PROVISIONS)
+Pallas-1786-441-370	369	Яствы	viands, provisions of food (noun)	Speißen	Cibus, Eßca		2550	VIANDS (PROVISIONS)
 Pallas-1786-441-371	370	Сыро	raw (noun)	Roh	Crudus	Crû	1959	RAW
 Pallas-1786-441-372	371	Варить	to boil (verb)	Kochen	Coquere	Cuire	1100	COOK (SOMETHING)
 Pallas-1786-441-373	372	Пиво	beer (noun)	Bier	Cervißia	Bière	1639	BEER

--- a/concepticondata/references/references.bib
+++ b/concepticondata/references/references.bib
@@ -217,7 +217,7 @@
 
 @Article{Bowern2011,
   Title                               = {Does Lateral Transmission Obscure Inheritance in Hunter-Gatherer Languages?},
-  Author                              = {Bowern, Claire and Epps, Patience and Gray, Russell and Hill, Jane and Hunley, Keith and McConvell, Patrick and Zentz, Jason},
+  Author                              = {Bowern, Claire and Epps, Patience and Gray, Russell D. and Hill, Jane and Hunley, Keith and McConvell, Patrick and Zentz, Jason},
   Journal                             = {PLoS ONE},
   Year                                = {2011},
   Doi                                 = {10.1371/journal.pone.0025195},
@@ -878,7 +878,7 @@
 
 @Article{Pagel2013,
   Title                               = {Ultraconserved words point to deep language ancestry across Eurasia},
-  Author                              = {Pagel, Mark and Atkinson, Quentin D. and CAlude, Andreea S. and Meade, Andrew},
+  Author                              = {Pagel, Mark and Atkinson, Quentin D. and Calude, Andreea S. and Meade, Andrew},
   Journal                             = {Proceedings of the National Acadamy of Science, USA},
   Year                                = {2013},
   Number                              = {21},

--- a/pyconcepticon/cli.py
+++ b/pyconcepticon/cli.py
@@ -19,11 +19,11 @@ from clldutils.clilib import ArgumentParser
 from clldutils.path import Path
 
 import pyconcepticon
-from pyconcepticon.commands import link, stats, attributes
+from pyconcepticon.commands import link, stats, attributes, overlap
 
 
 def main():  # pragma: no cover
-    parser = ArgumentParser(__name__, link, stats, attributes)
+    parser = ArgumentParser(__name__, link, stats, attributes, overlap)
     parser.add_argument(
         '--data',
         help="path to concepticon-data",

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -91,6 +91,15 @@ def attributes(args):
 
     print(tabulate(list(attrs.most_common()), headers=('Attribute', 'Occurrences')))
 
+def overlap(args):
+    """Compare how many concepts overlap in concept lists."""
+    api = Concepticon(args.data)
+    commons = defaultdict(set)
+    for arg in args.args:
+        for c in api.conceptlists[arg].concepts.values():
+            commons[c.concepticon_id].add(arg)
+    print(len([x for x, y in commons.items() if len(y) == len(args.args)]))
+
 
 def readme(outdir, text):
     with outdir.joinpath('README.md').open('w', encoding='utf8') as fp:

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -98,7 +98,10 @@ def overlap(args):
     for arg in args.args:
         for c in api.conceptlists[arg].concepts.values():
             commons[c.concepticon_id].add(arg)
-    print(len([x for x, y in commons.items() if len(y) == len(args.args)]))
+    out = len([x for x, y in commons.items() if len(y) == len(args.args)])
+    print(out)
+    return out
+
 
 
 def readme(outdir, text):

--- a/pyconcepticon/tests/test_commands.py
+++ b/pyconcepticon/tests/test_commands.py
@@ -53,7 +53,8 @@ class Tests(WithTempDir):
     def test_overlap(self):
         from pyconcepticon.commands import overlap
         Args = namedtuple('Args', ['data', 'args'])
-        self.assertEqual(
-                overlap(Args(data='', args=['Swadesh-1955-100',
-            'Swadesh-1952-200'])),
-                87)
+
+        with capture(overlap, Args(data='', args=['Swadesh-1955-100',
+            'Swadesh-1952-200'])) as out:
+            self.assertIn('87', out)
+

--- a/pyconcepticon/tests/test_commands.py
+++ b/pyconcepticon/tests/test_commands.py
@@ -6,8 +6,8 @@ from clldutils.path import copy, Path
 from clldutils.testing import WithTempDir, capture
 from clldutils.misc import nfilter
 from clldutils.clilib import ParserError
-
 from pyconcepticon.util import read_all
+from collections import namedtuple
 
 
 class Tests(WithTempDir):
@@ -49,3 +49,11 @@ class Tests(WithTempDir):
 
         with capture(attributes, MagicMock(data=None)) as out:
             self.assertIn('Occurrences', out)
+
+    def test_overlap(self):
+        from pyconcepticon.commands import overlap
+        Args = namedtuple('Args', ['data', 'args'])
+        self.assertEqual(
+                overlap(Args(data='', args=['Swadesh-1955-100',
+            'Swadesh-1952-200'])),
+                87)


### PR DESCRIPTION
this is practical. What I don't know how to solve is how to prevent the printed output in "tests".

I now also decided to put all missing items in Pallas as question marks. So I'd suppose, in the future, we'll use question marks to indicate missing translations.