### PR TITLE
speed up tests

### DIFF
--- a/pyconcepticon/tests/test_api.py
+++ b/pyconcepticon/tests/test_api.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals, print_function, division
 
 from clldutils.testing import capture
 
+from pyconcepticon.api import Concepticon
 from pyconcepticon.tests.util import TestWithFixture
 
 
@@ -36,23 +37,6 @@ class Tests(TestWithFixture):
         d['semanticfield'] = 'xx'
         with self.assertRaises(ValueError):
             Conceptset(**d)
-
-    def test_map(self):
-        from pyconcepticon.api import Concepticon
-
-        api = Concepticon()
-        if api.repos.exists():
-            with capture(api.map, self.fixture_path('conceptlist.tsv')) as out:
-                self.assertIn('CONCEPTICON_ID', out)
-
-            self.assertGreater(len(api.conceptsets['217'].concepts), 8)
-
-    def test_lookup(self):
-        from pyconcepticon.api import Concepticon
-        
-        api = Concepticon()
-        if api.repos.exists():
-            assert api.lookup(['sky']) == {'sky': ('1732', 'SKY')}
             
     def test_Conceptlist(self):
         from pyconcepticon.api import Conceptlist
@@ -68,8 +52,23 @@ class Tests(TestWithFixture):
 
         Reference(id=1, type='misc', record={'author': 'a', 'title': 't', 'year': 'y'})
 
+
+class TestConcepticon(TestWithFixture):
+    @classmethod
+    def setupClass(cls):
+        cls.api = Concepticon()
+        
+    def test_map(self):
+        if self.api.repos.exists():
+            with capture(self.api.map, self.fixture_path('conceptlist.tsv')) as out:
+                self.assertIn('CONCEPTICON_ID', out)
+
+            self.assertGreater(len(self.api.conceptsets['217'].concepts), 8)
+
+    def test_lookup(self):
+        if self.api.repos.exists():
+            assert self.api.lookup(['sky']) == {'sky': ('1732', 'SKY')}
+    
     def test_Concepticon(self):
-        from pyconcepticon.api import Concepticon
-        con = Concepticon()
-        assert len(con.frequencies) <= len(con.conceptsets)
+        assert len(self.api.frequencies) <= len(self.api.conceptsets)
     


### PR DESCRIPTION
This PR moves the tests requiring `Concepticon` into their own class, and makes them re-use a common `api` object to avoid the expensive set up times. It shaves about 4 seconds off the test run time(~25%). Thoughts? 