### PR TITLE
Fixes to lookup

### DIFF
--- a/pyconcepticon/api.py
+++ b/pyconcepticon/api.py
@@ -217,6 +217,9 @@ class Concepticon(object):
             print(writer.read().decode('utf-8'))
 
     def lookup(self, entries, full_search=False, similarity_level=5, language='en'):
+        """
+        :returns: `generator` of tuples (searchterm, concepticon_id, concepticon_gloss, similarity). 
+        """
         to = self._get_map_for_language(language, None)
         if full_search:
             cmap = concept_map2(
@@ -228,15 +231,13 @@ class Concepticon(object):
             )
         else:
             cmap = concept_map(entries, [i[1] for i in to], similarity_level=similarity_level)
-
-        out = {}
+        
         for i, e in enumerate(entries):
-            match = cmap.get(i, [None])[0]
-            out[e] = (
-                to[match][0] if match else None,
-                to[match][1].split("///")[0] if match else None
-            )
-        return out
+            match, simil = cmap.get(i, [[], 100])
+            if type(match) == int:  # yuck
+                match = [match]
+            for m in match:
+                yield (e, to[m][0], to[m][1].split("///")[0], simil)
 
 
 class Bag(object):

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -411,7 +411,7 @@ def lookup(args):
     api = Concepticon()
     found = api.lookup(args.args)
     with UnicodeWriter(None, delimiter='\t') as writer:
-        writer.writerow(['GLOSS', 'CONCEPTICON_ID', 'CONCEPTICON_GLOSS'])
-        for f in sorted(found):
-            writer.writerow([f, found[f][0], found[f][1]])
+        writer.writerow(['GLOSS', 'CONCEPTICON_ID', 'CONCEPTICON_GLOSS', 'SIMILARITY'])
+        for f in found:
+            writer.writerow(f)
         print(writer.read().decode('utf-8'))

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -409,7 +409,9 @@ def lookup(args):
     concepticon lookup <gloss1 gloss2 ... glossN>
     """
     api = Concepticon()
-    found = api.lookup(args.args)
+    found = api.lookup(
+        args.args, language=args.language, full_search=args.full_search, similarity_level=args.similarity
+    )
     with UnicodeWriter(None, delimiter='\t') as writer:
         writer.writerow(['GLOSS', 'CONCEPTICON_ID', 'CONCEPTICON_GLOSS', 'SIMILARITY'])
         for f in found:

--- a/pyconcepticon/tests/test_api.py
+++ b/pyconcepticon/tests/test_api.py
@@ -68,7 +68,9 @@ class TestConcepticon(TestWithFixture):
 
     def test_lookup(self):
         if self.api.repos.exists():
-            assert self.api.lookup(['sky']) == {'sky': ('1732', 'SKY')}
-
+            assert list(self.api.lookup(['sky'])) == [('sky', '1732', 'SKY', 2)]
+            # there are at least five 'thins' so lets see if we get them.
+            assert len(list(self.api.lookup(['thin'], full_search=True))) >= 5
+            
     def test_Concepticon(self):
         assert len(self.api.frequencies) <= len(self.api.conceptsets)

--- a/pyconcepticon/tests/test_commands.py
+++ b/pyconcepticon/tests/test_commands.py
@@ -77,7 +77,7 @@ class Tests(WithTempDirMixin, TestWithFixture):
     
     def test_lookup(self):
         from pyconcepticon.commands import lookup
-        with capture(lookup, MagicMock(args=['sky'])) as out:
+        with capture(lookup, MagicMock(args=['sky'], language='en')) as out:
             self.assertIn('1732', out)
         
         

--- a/pyconcepticon/tests/test_commands.py
+++ b/pyconcepticon/tests/test_commands.py
@@ -74,3 +74,10 @@ class Tests(WithTempDirMixin, TestWithFixture):
                 intersection,
                 Args(data='', args=['Swadesh-1955-100', 'Swadesh-1952-200'])) as out:
             self.assertEqual(94, len(out.split('\n')))
+    
+    def test_lookup(self):
+        from pyconcepticon.commands import lookup
+        with capture(lookup, MagicMock(args=['sky'])) as out:
+            self.assertIn('1732', out)
+        
+        

--- a/pyconcepticon/tests/test_glosses.py
+++ b/pyconcepticon/tests/test_glosses.py
@@ -37,8 +37,17 @@ class Tests(TestCase):
         g1 = Gloss.from_string('der Berg', language='de')
         g2 = Gloss.from_string('Berg')
         self.assertEqual(g1.similarity(g2), 4)
+
         g = Gloss.from_string('la montagne', language='fr')
         self.assertEqual(g.pos, '')
+        
+        g1 = Gloss.from_string('montagne', language='fr')
+        g2 = Gloss.from_string('la montagne', language='fr')
+        self.assertEqual(g1.similarity(g2), 6)
+        
+        # error on invalid gloss
+        with self.assertRaises(ValueError):
+            parse_gloss(None)
 
     def test_concept_map(self):
         from pyconcepticon.glosses import concept_map


### PR DESCRIPTION
I realised that `lookup` only returns one match instead of all matches. In fixing it, I've simplified the API to, rather than a dict of lists, return a generator of tuples (searchterm, concepticon gloss, concepticon id, similarity). 

This PR also adds a test or two.

There's an ugly `type(x) == int` check as it seems that the concept_map* commands can return either a bare integer or a list of integers. 
