### PR TITLE
Adding a utility 'check' to check wordlists

### DIFF
--- a/concepticondata/conceptlists/Tryon-1983-324.tsv
+++ b/concepticondata/conceptlists/Tryon-1983-324.tsv
@@ -138,7 +138,7 @@ Tryon-1983-324-136	136	stone	Geographical	857	STONE
 Tryon-1983-324-137	137	village	Geographical	930	VILLAGE
 Tryon-1983-324-138	138	bush	Geographical	1683	BUSH
 Tryon-1983-324-139	139	day	Physical Astronomy Meteorology	1225	DAY (NOT NIGHT)
-Tryon-1983-324-140	140	might	Physical Astronomy Meteorology		
+Tryon-1983-324-140	140	night	Physical Astronomy Meteorology	1233	NIGHT
 Tryon-1983-324-141	141	morning	Physical Astronomy Meteorology	1339	MORNING
 Tryon-1983-324-142	142	year	Physical Astronomy Meteorology	1226	YEAR
 Tryon-1983-324-143	143	yesterday	Physical Astronomy Meteorology	1174	YESTERDAY

--- a/concepticondata/conceptlists/Tryon-1983-324.tsv
+++ b/concepticondata/conceptlists/Tryon-1983-324.tsv
@@ -168,8 +168,8 @@ Tryon-1983-324-166	166	we pl. incl.	Personal Pronouns	1131	WE (INCLUSIVE)
 Tryon-1983-324-167	167	we pl. excl.	Personal Pronouns	1130	WE (EXCLUSIVE)
 Tryon-1983-324-168	168	you pl.	Personal Pronouns	1213	YOU
 Tryon-1983-324-169	169	they	Personal Pronouns	817	THEY
-Tryon-1983-324-170	170	we dl. incl.	Personal Pronouns	1131	WE (INCLUSIVE)
-Tryon-1983-324-171	171	we dl. excl.	Personal Pronouns	1130	WE (EXCLUSIVE)
+Tryon-1983-324-170	170	we dl. incl.	Personal Pronouns	2637	WE TWO (INCLUSIVE)
+Tryon-1983-324-171	171	we dl. excl.	Personal Pronouns	2636	WE TWO (EXCLUSIVE)
 Tryon-1983-324-172	172	you dl.	Personal Pronouns	1213	YOU
 Tryon-1983-324-173	173	they dl.	Personal Pronouns	817	THEY
 Tryon-1983-324-174	174	my	Possessives	2090	MY

--- a/pyconcepticon/cli.py
+++ b/pyconcepticon/cli.py
@@ -20,7 +20,7 @@ from clldutils.clilib import ArgumentParser
 from clldutils.path import Path
 
 from pyconcepticon.commands import (
-    link, stats, attributes, intersection, union, map_concepts, upload_sources, lookup
+    link, stats, attributes, intersection, union, map_concepts, upload_sources, lookup, check
 )
 import pyconcepticon
 
@@ -35,7 +35,8 @@ def main():  # pragma: no cover
         union,
         upload_sources,
         map_concepts,
-        lookup)
+        lookup,
+        check)
     parser.add_argument(
         '--data',
         help="path to concepticon-data",

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -427,9 +427,9 @@ def check(args):
     concepticon check <dataset>
     """
     
-    def _pprint(clist, error, _id, *extra):
+    def _pprint(clist, error, _id, message):
         print("\t".join([
-            clist.ljust(30), error.ljust(10), '%5s' % _id, *extra
+            clist.ljust(30), error.ljust(10), '%5s' % _id, message
             
         ]))
     

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -417,3 +417,56 @@ def lookup(args):
         for f in found:
             writer.writerow(f)
         print(writer.read().decode('utf-8'))
+
+
+def check(args):
+    """
+    Identifies some issues with wordlists 
+    -- i.e. multiple words with the same CONCEPTICON_ID or missing definitions
+
+    concepticon check <dataset>
+    """
+    
+    def _pprint(clist, error, _id, *extra):
+        print("\t".join([
+            clist.ljust(30), error.ljust(10), '%5s' % _id, *extra
+            
+        ]))
+    
+    def _get_clashes(api, clist):
+        o = api.conceptlists[clist]
+        # clashes
+        clashes = defaultdict(list)
+        for c in o.concepts:
+            clashes[o.concepts[c].concepticon_id].append(c)
+        
+        if '' in clashes:
+            clashes.pop('')
+        
+        for c in sorted([c for c in clashes if len(clashes[c]) > 1]):
+            matches = [m for m in o.concepts if o.concepts[m].concepticon_id == c]
+            for i, m in enumerate(matches, 1):
+                message = '#%d %s = "%s"' % (
+                    i,
+                    api.conceptsets[c].gloss,
+                    getattr(o.concepts[m], 'english', '')
+                )
+                _pprint(clist, 'DUPLICATE', c, message)
+        
+    def _get_missing(api, clist):
+        o = api.conceptlists[clist]
+        missings = [c for c in o.concepts if o.concepts[c].concepticon_id == ""]
+        concepts = api.conceptlists[clist].concepts
+        for m in missings:
+            _pprint(clist, 'MISSING', concepts[m].number, '"%s"' % concepts[m].english)
+    
+    api = Concepticon(args.data)
+    # conceptlists to check
+    if len(args.args):
+        clists = [_ for _ in api.conceptlists if _ in args.args]
+    else:
+        clists = api.conceptlists
+    # check
+    for clist in clists:
+        _get_missing(api, clist)
+        _get_clashes(api, clist)

--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -433,7 +433,7 @@ def check(args):
             
         ]))
     
-    def _get_clashes(api, clist):
+    def _get_mergers(api, clist):
         o = api.conceptlists[clist]
         # clashes
         clashes = defaultdict(list)
@@ -451,7 +451,7 @@ def check(args):
                     api.conceptsets[c].gloss,
                     getattr(o.concepts[m], 'english', '')
                 )
-                _pprint(clist, 'DUPLICATE', c, message)
+                _pprint(clist, 'MERGE', c, message)
         
     def _get_missing(api, clist):
         o = api.conceptlists[clist]
@@ -469,4 +469,4 @@ def check(args):
     # check
     for clist in clists:
         _get_missing(api, clist)
-        _get_clashes(api, clist)
+        _get_mergers(api, clist)


### PR DESCRIPTION
I'm looking to add the Tryon and Hackman data to Lexibank and I noticed that we've already redefined a few words (dual/plural 'we'). This is also going to become more complicated as concepticon grows. 

So, I to help with this sort of revision, I wrote a utility `concepticon check <dataset>` to check for duplicates and missing glosses.  e.g. here's what `concepticon check Tryon-1983-324`. 

```
Tryon-1983-324                	MISSING   	   57	"hornbill"
Tryon-1983-324                	MISSING   	   62	"midge"
Tryon-1983-324                	MISSING   	   88	"hibiscus til."
Tryon-1983-324                	MISSING   	   94	"turmeric"
Tryon-1983-324                	MISSING   	   96	"alstonia sp."
Tryon-1983-324                	MISSING   	   97	"vitex cofassus"
Tryon-1983-324                	MISSING   	  113	"calico"
Tryon-1983-324                	MISSING   	  128	"headland"
Tryon-1983-324                	DUPLICATE 	 1213	#1 YOU = "you pl."
Tryon-1983-324                	DUPLICATE 	 1213	#2 YOU = "you dl."
Tryon-1983-324                	DUPLICATE 	   53	#1 SPIRIT = "spirit (dead)"
Tryon-1983-324                	DUPLICATE 	   53	#2 SPIRIT = "spirit (live)"
Tryon-1983-324                	DUPLICATE 	  780	#1 OUR = "our pl. incl."
Tryon-1983-324                	DUPLICATE 	  780	#2 OUR = "our pl. Excl."
Tryon-1983-324                	DUPLICATE 	  817	#1 THEY = "they"
Tryon-1983-324                	DUPLICATE 	  817	#2 THEY = "they dl."
```

i.e. a duplicate is any concepticon_id that is included multiple times in one dataset. I know this can happen, but I think it's an easy way to flag definitions that may need splitting. 

Maybe not useful for anyone but me but thought I'd add a PR anyway.
