### PR TITLE
exposing test command in API

### DIFF
--- a/pyconcepticon/commands.py
+++ b/pyconcepticon/commands.py
@@ -485,3 +485,9 @@ def check(args):
     for clist in clists:
         _get_missing(api, clist)
         _get_mergers(api, clist)
+
+
+@command()
+def test(args):
+    from pyconcepticon.tests.test_data import test as _test
+    _test()


### PR DESCRIPTION
This small PR makes the command `concepticon test` run the tests in test_data. This means that data integrity can be checked locally instead of waiting for travis.