### PR TITLE
fix utf-8-sig problem and allow for more flexible handling of local concept lists

### DIFF
--- a/concepticondata/conceptlists/default-metadata.json
+++ b/concepticondata/conceptlists/default-metadata.json
@@ -3,7 +3,8 @@
     "dialect": {
         "header": true,
         "skipBlankRows": true,
-        "delimiter": "\t"
+        "delimiter": "\t",
+	"encoding": "utf-8-sig"
     },
     "tables": [
         {

--- a/concepticondata/conceptlists/local-metadata.json
+++ b/concepticondata/conceptlists/local-metadata.json
@@ -1,0 +1,51 @@
+{
+    "@context": ["http://www.w3.org/ns/csvw", {"@language": "en"}],
+    "dialect": {
+        "header": true,
+        "skipBlankRows": true,
+        "delimiter": "\t",
+	"encoding": "utf-8-sig"
+    },
+    "tables": [
+        {
+            "url": null,
+            "tableSchema": {
+                "columns": [
+                    {
+                        "name": "ID",
+                        "datatype": {
+                            "base": "string"
+                        }
+                    },
+                    {
+                        "name": "NUMBER",
+                        "datatype": {
+                            "base": "string",
+                            "format": "[0-9\\.]+([a-z\\–]+)?$"
+                        }
+                    },
+                    {
+                        "name": "CONCEPTICON_ID",
+                        "datatype": {
+                            "base": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "CONCEPTICON_GLOSS",
+                        "datatype": "string"
+                    },
+                    {
+                        "name": "GLOSS",
+                        "datatype": "string"
+                    },
+                    {
+                        "name": "ENGLISH",
+                        "datatype": "string"
+                    }
+                ],
+                "primaryKey": "ID"
+            }
+        }
+    ]
+}

--- a/pyconcepticon/api.py
+++ b/pyconcepticon/api.py
@@ -387,6 +387,7 @@ class Conceptlist(Bag):
     note = attr.ib()
     pages = attr.ib()
     alias = attr.ib(convert=lambda s: [] if s is None else split(s))
+    local = attr.ib(default=False)
 
     @property
     def metadata(self):
@@ -394,7 +395,10 @@ class Conceptlist(Bag):
         if not md.exists():
             ddir = self._api.data_path() if hasattr(self._api, 'data_path') \
                 else REPOS_PATH.joinpath('concepticondata')
-            md = ddir.joinpath('conceptlists', 'default-metadata.json')
+            if self.local:
+                md = ddir.joinpath('conceptlists', 'local-metadata.json')
+            else:
+                md = ddir.joinpath('conceptlists', 'default-metadata.json')
         tg = TableGroup.from_file(md)
         if isinstance(self._api, Path):
             tg._fname = self._api.parent.joinpath(self._api.name + '-metadata.json')
@@ -436,5 +440,6 @@ class Conceptlist(Bag):
         attrs.update(
             id=path.stem,
             items=keywords.get('items', len(read_dicts(path))),
-            year=keywords.get('year', 0))
+            year=keywords.get('year', 0),
+            local=True)
         return cls(api=path, **attrs)

--- a/pyconcepticon/glosses.py
+++ b/pyconcepticon/glosses.py
@@ -103,6 +103,7 @@ def parse_gloss(gloss, language='en'):
     and may thus help to compare different glosses across different resources.
     """
     if not gloss:
+        print(gloss)
         raise ValueError("Your gloss is empty")
     G = []
     gpos = ''


### PR DESCRIPTION
This allows to have simple IDs in local concept lists, which makes it easier to compare them, since otherwise, users who want to quickly check for intersection and the like, will be bored by adding the Author-YEAR-NUMBER-etc. ids. It should turn into a cli-function that allows for the quick checking whether a concept-list is okay, giving verbose and useful output to the user (e.g., which keys are not unique, etc.). We may also consider dropping the ID requirement altogether (or the number) for this kind of concept list application.