### PR TITLE
Data consistency

### DIFF
--- a/concepticondata/concept_set_meta/webster.tsv
+++ b/concepticondata/concept_set_meta/webster.tsv
@@ -12,7 +12,7 @@ CONCEPTICON_ID	WEBSTER_ID
 2887	thaw
 2888	tinkle
 2889	twinkle
-2913	immediately
+1963	immediately
 2915	at first
 2916	instantly
 2917	next to

--- a/concepticondata/conceptlists/Bender-1971-99.tsv
+++ b/concepticondata/conceptlists/Bender-1971-99.tsv
@@ -57,7 +57,6 @@ Bender-1971-99-55	55	name	1405	NAME
 Bender-1971-99-56	56	neck	1333	NECK
 Bender-1971-99-57	57	new	1231	NEW
 Bender-1971-99-58	58	night	1233	NIGHT
-Bender-1971-99-59	59	-		
 Bender-1971-99-60	60	nose	1221	NOSE
 Bender-1971-99-61	61	one	1493	ONE
 Bender-1971-99-62	62	other	197	OTHER


### PR DESCRIPTION
This PR fixes two data consistency problems which surfaced when trying to load the data into the clld app.

Judging from the import code, at some point we decided that concept lists must only have concepts with valid glosses. We had a similar policy which required all concepts to have valid values for all additional columns in a conceptlist, but this is violated quite heavily by Luniewska-2016-299, so I relaxed this requirement.