### PR TITLE
Added checking for leading and trailing spaces.

### DIFF
--- a/pyconcepticon/check_data.py
+++ b/pyconcepticon/check_data.py
@@ -105,8 +105,16 @@ def check(api=None):
                     error('missing source language translation %s' % lg, cl.id, i + 2)
             for attr, values in ref_cols.items():
                 val = getattr(concept, attr)
-                if val and val not in values:  # pragma: no cover
-                    error('invalid value for %s: %s' % (attr, val), cl.id, i + 2)
+                if val:
+                    # check that there are not leading and trailing spaces
+                    # (while computationally expensive, this helps catch really
+                    # hard to find typos)
+                    if val != val.strip():
+                        error("leading or trailing spaces in value for %s: '%s'" %
+                              (attr, val), cl.id, i+2)
+
+                    if val not in values:  # pragma: no cover
+                        error('invalid value for %s: %s' % (attr, val), cl.id, i + 2)
 
     sameas = {}
     glosses = set()


### PR DESCRIPTION
Solves [issue 474](https://github.com/clld/concepticon-data/issues/474) and the [problem](https://github.com/clld/concepticon-data/pull/467#issuecomment-382791407) pointed by @Anaphory .

It is computationally expensive, but I still think it is worth. I once also had a problem with a trailing space and it took me a lot to figure it out.

I am not checking for the same problem in the main files (`concepticon.tsv`, etc.), it does not seem necessary and, in any case, errors introduced there would be caught by this checking when running on the individual concept lists.